### PR TITLE
net/sched: add action inheritdsfield to skbedit

### DIFF
--- a/tc/m_skbedit.c
+++ b/tc/m_skbedit.c
@@ -30,16 +30,18 @@
 
 static void explain(void)
 {
-	fprintf(stderr, "Usage: ... skbedit <[QM] [PM] [MM] [PT]>\n"
+	fprintf(stderr, "Usage: ... skbedit <[QM] [PM] [MM] [PT] [IF]>\n"
 		"QM = queue_mapping QUEUE_MAPPING\n"
 		"PM = priority PRIORITY\n"
 		"MM = mark MARK\n"
 		"PT = ptype PACKETYPE\n"
+		"IF = inheritdsfield\n"
 		"PACKETYPE = is one of:\n"
 		"  host, otherhost, broadcast, multicast\n"
 		"QUEUE_MAPPING = device transmit queue to use\n"
 		"PRIORITY = classID to assign to priority field\n"
-		"MARK = firewall mark to set\n");
+		"MARK = firewall mark to set\n"
+		"note: inheritdsfield maps DS field to skb->priority\n");
 }
 
 static void
@@ -60,6 +62,7 @@ parse_skbedit(struct action_util *a, int *argc_p, char ***argv_p, int tca_id,
 	unsigned int tmp;
 	__u16 queue_mapping, ptype;
 	__u32 flags = 0, priority, mark;
+	__u64 pure_flags = 0;
 	struct tc_skbedit sel = { 0 };
 
 	if (matches(*argv, "skbedit") != 0)
@@ -111,6 +114,9 @@ parse_skbedit(struct action_util *a, int *argc_p, char ***argv_p, int tca_id,
 			}
 			flags |= SKBEDIT_F_PTYPE;
 			ok++;
+		} else if (matches(*argv, "inheritdsfield") == 0) {
+			pure_flags |= SKBEDIT_F_INHERITDSFIELD;
+			ok++;
 		} else if (matches(*argv, "help") == 0) {
 			usage();
 		} else {
@@ -156,6 +162,8 @@ parse_skbedit(struct action_util *a, int *argc_p, char ***argv_p, int tca_id,
 	if (flags & SKBEDIT_F_PTYPE)
 		addattr_l(n, MAX_MSG, TCA_SKBEDIT_PTYPE,
 			  &ptype, sizeof(ptype));
+	if (pure_flags != 0)
+		addattr64(n, MAX_MSG, TCA_SKBEDIT_FLAGS, pure_flags);
 	addattr_nest_end(n, tail);
 
 	*argc_p = argc;
@@ -213,6 +221,13 @@ static int print_skbedit(struct action_util *au, FILE *f, struct rtattr *arg)
 				     "otherhost");
 		else
 			print_uint(PRINT_ANY, "ptype", " ptype %u", ptype);
+	}
+	if (tb[TCA_SKBEDIT_FLAGS] != NULL) {
+		__u64 flags = rta_getattr_u64(tb[TCA_SKBEDIT_FLAGS]);
+
+		if (flags & SKBEDIT_F_INHERITDSFIELD)
+			print_null(PRINT_ANY, "inheritdsfield", " %s",
+				     "inheritdsfield");
 	}
 
 	print_action_control(f, " ", p->action, "");


### PR DESCRIPTION
The new action inheritdsfield copies the field DS of
IPv4 and IPv6 packets into skb->priority. This enables
later classification of packets based on the DS field.

Original idea by Jamal Hadi Salim <jhs@mojatatu.com>

Signed-off-by: Qiaobin Fu <qiaobinf@bu.edu>
Reviewed-by: Michel Machado <michel@digirati.com.br>
---

Note that the motivation for this patch is found in the following discussion:
https://www.spinics.net/lists/netdev/msg501061.html